### PR TITLE
add tests with base 1000 and reminder > 100

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -56,7 +56,7 @@ TESTS = {
             "input": [9841, 3],
             "answer": True
         },
-       {
+        {
             "input": [20, 4],
             "answer": False
         },
@@ -149,8 +149,8 @@ TESTS = {
             "input": [9_909_009, 1000],
             "answer": True,
             "explanation": "9_909_009, 1_000: large Base, large remainder"
-       },
-       {
+        },
+        {
             "input": [9909008, 1000],
             "answer": False
             "explanation": "9_909_008, 1_000: large Base, large remainder"

--- a/verification/tests.py
+++ b/verification/tests.py
@@ -56,7 +56,7 @@ TESTS = {
             "input": [9841, 3],
             "answer": True
         },
-        {
+       {
             "input": [20, 4],
             "answer": False
         },
@@ -139,6 +139,21 @@ TESTS = {
         {
             "input": [4545, 100],
             "answer": True
+        },
+        {
+            "input": [1010001, 1000],
+            "answer": True,
+            "explanation": "1_010_001, 1_000: large Base, small remainder"
+        },
+        {
+            "input": [9_909_009, 1000],
+            "answer": True,
+            "explanation": "9_909_009, 1_000: large Base, large remainder"
+       },
+       {
+            "input": [9909008, 1000],
+            "answer": False
+            "explanation": "9_909_008, 1_000: large Base, large remainder"
         }
     ]
 }

--- a/verification/tests.py
+++ b/verification/tests.py
@@ -146,7 +146,7 @@ TESTS = {
             "explanation": "1_010_001, 1_000: large Base, small remainder"
         },
         {
-            "input": [9_909_009, 1000],
+            "input": [9909009, 1000],
             "answer": True,
             "explanation": "9_909_009, 1_000: large Base, large remainder"
         },


### PR DESCRIPTION
When we allow any base B >= 2, then we should also test some larger bases and also higher "digits" in the numbers 

PS: These additional tests will break solutions which rely on forming a number using constructions like:
- `digs = string.digits + string.ascii_letters`    
- `digits.append(digs[x % base])`
